### PR TITLE
Change the encrypted data token member to line up with the current Android Pay spec (data -> encryptedMessage)

### DIFF
--- a/test/fixtures/token.json
+++ b/test/fixtures/token.json
@@ -1,5 +1,5 @@
 {
-"data": "V65NNwqzK0A1bi0F96HQZr4eFA8fWCatwykv3sFA8Cg4Wn4Ylk/szN6GiFTuYQFrHA7a/h0P3tfEQd09bor6pRqrM8/Bt12R0SHKtnQxbYxTjpMr/7C3Um79n0jseaPlK8+CHXljbYifwGB+cEFh/smP8IO1iw3TL/192HesutfVMKm9zpo5mLNzQ2GMU4JWUGIgrzsew6S6XshelrjE",
+"encryptedMessage": "V65NNwqzK0A1bi0F96HQZr4eFA8fWCatwykv3sFA8Cg4Wn4Ylk/szN6GiFTuYQFrHA7a/h0P3tfEQd09bor6pRqrM8/Bt12R0SHKtnQxbYxTjpMr/7C3Um79n0jseaPlK8+CHXljbYifwGB+cEFh/smP8IO1iw3TL/192HesutfVMKm9zpo5mLNzQ2GMU4JWUGIgrzsew6S6XshelrjE",
 "ephemeralPublicKey": "BB9cOXHgf3KcY8dbsU6fhzqTJm3JFvzD+8wcWg0W9r+Xl5gYjoZRxHuYocAx3g82v2o0Le1E2w4sDDl5w3C0lmY=",
 "tag": "boJLmOxDduTV5a34CO2IRbgxUjZ9WmfzxNl1lWqQ+Z0="
 }

--- a/test/initial_dev/test_data.md
+++ b/test/initial_dev/test_data.md
@@ -8,7 +8,7 @@ Note: for the HDFK step, the keying material is the ephemeral public key + the s
 ```
 {
 "ephemeralPublicKey":"BPhVspn70Zj2Kkgu9t8+ApEuUWsI/zos5whGCQBlgOkuYagOis7qsrcbQrcprjvTZO3XOU+Qbcc28FSgsRtcgQE=",
-"data":"PHxZxBQvVWwP",
+"encryptedMessage":"PHxZxBQvVWwP",
 "tag":"s9wa3Q2WiyGi/eDA4XYVklq08KZiSxB7xvRiKK3H7kE="
 }
 ```

--- a/test/initial_dev/test_data_token.json
+++ b/test/initial_dev/test_data_token.json
@@ -1,5 +1,5 @@
 {
 "ephemeralPublicKey":"BPhVspn70Zj2Kkgu9t8+ApEuUWsI/zos5whGCQBlgOkuYagOis7qsrcbQrcprjvTZO3XOU+Qbcc28FSgsRtcgQE=",
-"data":"PHxZxBQvVWwP",
+"encryptedMessage":"PHxZxBQvVWwP",
 "tag":"s9wa3Q2WiyGi/eDA4XYVklq08KZiSxB7xvRiKK3H7kE="
 }

--- a/test/payment_token_test.rb
+++ b/test/payment_token_test.rb
@@ -18,7 +18,7 @@ class R2D2::PaymentTokenTest < Test::Unit::TestCase
   def test_initialize
     assert_equal @token_attrs["ephemeralPublicKey"], @payment_token.ephemeral_public_key
     assert_equal @token_attrs["tag"], @payment_token.tag
-    assert_equal @token_attrs["data"], @payment_token.data
+    assert_equal @token_attrs["encryptedMessage"], @payment_token.encrypted_message
   end
 
   def test_successful_decrypt


### PR DESCRIPTION
As per spec changes in https://developers.google.com/android-pay/integration/gateway-processor-integration#retrieving-the-encrypted-payload

@rwdaigle @mrezentes 
