### PR TITLE
Prefer constant time array comparison to avoid timing attacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,27 @@ JSON.parse(decrypted_json)
 }
 ```
 
+The library implements a constant time comparison algorithm for preventing timing attacks. The pure ruby implementation is quite inefficient (but portable) and thus r2d2 also supports a faster variation backed by [fast_secure_compare](https://github.com/daxtens/fast_secure_compare). To enable `FastSecureCompare` in your environment, add the following to your Gemfile:
+
+```ruby
+gem 'fast_secure_compare`
+```
+
+and require the extension in your application prior to loading r2d2:
+
+```
+require 'fast_secure_compare/fast_secure_compare'
+require 'r2d2/payment_token'
+```
+
+Benchmarks illustrating the overhead of the pure Ruby version:
+
+```
+                          user     system      total        real
+secure_compare        1.070000   0.010000   1.080000 (  1.231714)
+fast secure_compare   0.050000   0.000000   0.050000 (  0.049753)
+```
+
 ## Testing
 
 ```session

--- a/lib/r2d2/payment_token.rb
+++ b/lib/r2d2/payment_token.rb
@@ -62,15 +62,21 @@ module R2D2
         payload.unpack('U*').collect { |el| el.chr }.join
       end
 
-      # constant-time comparison algorithm to prevent timing attacks; borrowed from ActiveSupport::MessageVerifier
-      def secure_compare(a, b)
-        return false unless a.bytesize == b.bytesize
+      if defined?(FastSecureCompare)
+        def secure_compare(a, b)
+          FastSecureCompare.compare(a, b)
+        end
+      else
+        # constant-time comparison algorithm to prevent timing attacks; borrowed from ActiveSupport::MessageVerifier
+        def secure_compare(a, b)
+          return false unless a.bytesize == b.bytesize
 
-        l = a.unpack("C#{a.bytesize}")
+          l = a.unpack("C#{a.bytesize}")
 
-        res = 0
-        b.each_byte { |byte| res |= byte ^ l.shift }
-        res == 0
+          res = 0
+          b.each_byte { |byte| res |= byte ^ l.shift }
+          res == 0
+        end
       end
     end
   end

--- a/lib/r2d2/payment_token.rb
+++ b/lib/r2d2/payment_token.rb
@@ -50,7 +50,7 @@ module R2D2
 
       def verify_mac(digest, mac_key, encrypted_message, tag)
         mac = OpenSSL::HMAC.digest(digest, mac_key, Base64.decode64(encrypted_message))
-        raise TagVerificationError unless mac == Base64.decode64(tag)
+        raise TagVerificationError unless secure_compare(mac, Base64.decode64(tag))
       end
 
       def decrypt_message(encrypted_data, symmetric_key)
@@ -62,6 +62,16 @@ module R2D2
         payload.unpack('U*').collect { |el| el.chr }.join
       end
 
+      # constant-time comparison algorithm to prevent timing attacks; borrowed from ActiveSupport::MessageVerifier
+      def secure_compare(a, b)
+        return false unless a.bytesize == b.bytesize
+
+        l = a.unpack("C#{a.bytesize}")
+
+        res = 0
+        b.each_byte { |byte| res |= byte ^ l.shift }
+        res == 0
+      end
     end
   end
 end


### PR DESCRIPTION
As per https://developers.google.com/android-pay/integration/gateway-processor-integration#decrypting-the-payment-token

```
Verify that the tag field is a valid MAC for encryptedMessage:
For generating the expected MAC, use HMAC (RFC 5869) with hash function SHA256 and the macKey obtained above
Remember to use a constant time array comparison to avoid timing attacks <<<<<<
```

Test output:

```
Lourenss-Air:r2d2 lourens$ bundle exec ruby test/payment_token_test.rb
Loaded suite test/payment_token_test
Started
.....

Finished in 0.028849 seconds.
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
5 tests, 13 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
173.32 tests/s, 450.62 assertions/s
```

@rwdaigle @mrezentes