### PR TITLE
Unlock HKDF version to match Gemspec requirement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source 'https://rubygems.org'
 
 gemspec
-
-gem 'hkdf', '~> 0.2.0'


### PR DESCRIPTION
Latest is 0.3.0.