### PR TITLE
Changes to maintain ruby 1.8.7 compatability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,6 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'hkdf', '~> 0.2.0'
+
+# For Ruby 1.8.7 compatability
+gem 'json', '1.8.6' if RUBY_VERSION < '1.9'

--- a/construi.yml
+++ b/construi.yml
@@ -1,0 +1,34 @@
+image: scratch
+
+environment:
+  - BUNDLE_APP_CONFIG=$PWD/.bundle
+  - BUNDLE_APP_PATH=$PWD/.bundle
+  - HOME=$PWD
+
+targets:
+  test-ruby18:
+    image: everydayhero/ruby-ree
+    run: &run-tests
+      - bundle config path vendor/bundle
+      - bundle update
+      - bundle exec rake
+
+  test-ruby19:
+    image: ruby:1.9
+    run: *run-tests
+
+  test-ruby21:
+    image: ruby:2.1
+    run: *run-tests
+
+  test-ruby22:
+    image: ruby:2.2
+    run: *run-tests
+
+  test:
+    before:
+      - test-ruby18
+      - test-ruby19
+      - test-ruby21
+      - test-ruby22
+

--- a/lib/r2d2.rb
+++ b/lib/r2d2.rb
@@ -1,3 +1,3 @@
 require "json"
 
-require_relative "r2d2/payment_token"
+require "r2d2/payment_token"

--- a/lib/r2d2/payment_token.rb
+++ b/lib/r2d2/payment_token.rb
@@ -57,7 +57,6 @@ module R2D2
         decipher = OpenSSL::Cipher::AES128.new(:CTR)
         decipher.decrypt
         decipher.key = symmetric_key
-        decipher.auth_data = ""
         decipher.update(Base64.decode64(encrypted_data)) + decipher.final
       end
 

--- a/r2d2.gemspec
+++ b/r2d2.gemspec
@@ -20,8 +20,9 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'hkdf'
 
-  s.add_development_dependency "bundler", "~> 1.15"
-  s.add_development_dependency "rake", "~> 12.0"
+  s.add_development_dependency "bundler", "~> 1.9"
+  s.add_development_dependency "rake", "~> 10.5"
   s.add_development_dependency "minitest", "~> 5.0"
-  s.add_development_dependency "pry-byebug"
+
+  s.add_development_dependency "pry-byebug" if RUBY_VERSION > '2.2.0'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,4 +2,10 @@ $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "r2d2"
 
 require "minitest/autorun"
-require "pry-byebug"
+
+begin
+  require "pry-byebug"
+rescue LoadError
+  # Ignore, byebug is not installed for older ruby versions
+end
+


### PR DESCRIPTION
This PR suggests the following changes:
* Those to allow ruby 1.8.7 compatability
* Adds construi.yml, a tool that makes use of docker-compose to allow running against multiple containers. (Similar to what CircleCI is doing, but can be run locally)

