### PR TITLE
Add license to gemspec

### DIFF
--- a/r2d2.gemspec
+++ b/r2d2.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.homepage          = "https://github.com/spreedly/r2d2"
   s.summary           = "Android Pay payment token decryption library"
   s.description       = "Given an (encrypted) Android Pay token, verify and decrypt it"
+  s.license           = "MIT"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
In https://github.com/spreedly/r2d2/commit/f8370b74a039aef1aebb8e30c76aa1b1709457f1 the MIT license was added, this adds that to the gemspec with [the rubygems format](https://guides.rubygems.org/specification-reference/#license=).

Thanks for making this gem!